### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,9 +52,11 @@ i18next.t('key2', { postProcess: 'sprintf', sprintf: { users: [{name: 'Dolly'}, 
 import i18next from 'i18next';
 import sprintf from 'i18next-sprintf-postprocessor';
 
-i18next.init({
-  overloadTranslationOptionHandler: sprintf.overloadTranslationOptionHandler
-});
+i18next
+  .use(sprintf)
+  .init({
+    overloadTranslationOptionHandler: sprintf.overloadTranslationOptionHandler
+  });
 
 // given loaded resources
 // translation: {


### PR DESCRIPTION
in order to be functioning correctly `.use(sprintf)` must be called on `i18next` even in the second example of README
this took me quite some time to figure out why sprintf isn't working in second scenario and I want it to be clear to other developers